### PR TITLE
make use of the bind helper for window.btoa

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -5,8 +5,9 @@ var settle = require('./../core/settle');
 var buildURL = require('./../helpers/buildURL');
 var parseHeaders = require('./../helpers/parseHeaders');
 var isURLSameOrigin = require('./../helpers/isURLSameOrigin');
+var bind = require('./../helpers/bind');
 var createError = require('../core/createError');
-var btoa = (typeof window !== 'undefined' && window.btoa && window.btoa.bind(window)) || require('./../helpers/btoa');
+var btoa = (typeof window !== 'undefined' && window.btoa && bind(window.btoa, window)) || require('./../helpers/btoa');
 
 module.exports = function xhrAdapter(config) {
   return new Promise(function dispatchXhrRequest(resolve, reject) {


### PR DESCRIPTION
Fixes a failure in environments that have `window.btoa` but lack native `Function.bind`